### PR TITLE
feat: Stale game cleanup and API

### DIFF
--- a/game-server/cmd/flipcup/main.go
+++ b/game-server/cmd/flipcup/main.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
+
 	"flip-cup/internal/game"
 	"flip-cup/internal/transport/ws"
 	"flip-cup/internal/transport/api"
@@ -15,6 +17,16 @@ func main() {
     log.Println("✅ Flip Cup server started")
 	
 	manager := game.NewGameManager()
+
+	// Start background cleanup task
+	go func() {
+		// Run cleanup every 30 minutes, removing games inactive for > 1 hour
+		ticker := time.NewTicker(30 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			manager.CleanupStaleGames(1 * time.Hour)
+		}
+	}()
 
 	// Create a new router
 	r := mux.NewRouter()

--- a/game-server/internal/game/cleanup_test.go
+++ b/game-server/internal/game/cleanup_test.go
@@ -1,0 +1,71 @@
+package game
+
+import (
+	"testing"
+	"time"
+	"flip-cup/internal/quiz"
+)
+
+func TestCleanupStaleGames(t *testing.T) {
+	// 1. Setup
+	gm := NewGameManager()
+	
+	// Create a minimal QuestionFile structure
+	qf := &quiz.QuestionFile{
+		Filename: "test.yaml",
+		// We don't need actual questions for this test
+		Questions: []*quiz.Question{},
+	}
+
+	// 2. Create games
+	g1 := gm.NewGame(qf)
+	g2 := gm.NewGame(qf)
+
+	// 3. Manipulate LastActivity
+	// g1 is active now (default NewGame sets to Now())
+	// g2 should be stale. We set it to 2 hours ago.
+	g2.mu.Lock()
+	g2.LastActivity = time.Now().Add(-2 * time.Hour)
+	g2.mu.Unlock()
+
+	// 4. Run Cleanup with 1 hour threshold
+	// g2 is 2 hours old, so it > 1 hour, should be deleted.
+	gm.CleanupStaleGames(1 * time.Hour)
+
+	// 5. Verify
+	if gm.GetGame(g1.ID) == nil {
+		t.Errorf("Game 1 (active) should still exist")
+	}
+	if gm.GetGame(g2.ID) != nil {
+		t.Errorf("Game 2 (stale) should have been deleted")
+	}
+}
+
+func TestGetStaleGames(t *testing.T) {
+	gm := NewGameManager()
+	qf := &quiz.QuestionFile{Filename: "test.yaml"}
+
+	g1 := gm.NewGame(qf)
+	g2 := gm.NewGame(qf)
+
+	// Make g2 stale
+	g2.mu.Lock()
+	g2.LastActivity = time.Now().Add(-40 * time.Minute)
+	g2.mu.Unlock()
+
+	// Threshold 30m
+	stale := gm.GetStaleGames(30 * time.Minute)
+
+	if len(stale) != 1 {
+		t.Errorf("Expected 1 stale game, got %d", len(stale))
+	} else if stale[0].ID != g2.ID {
+		t.Errorf("Expected stale game ID %s, got %s", g2.ID, stale[0].ID)
+	}
+
+    // Ensure g1 (active) is not returned
+    for _, s := range stale {
+        if s.ID == g1.ID {
+            t.Errorf("Active game %s should not be marked stale", g1.ID)
+        }
+    }
+}

--- a/game-server/internal/game/game.go
+++ b/game-server/internal/game/game.go
@@ -30,6 +30,7 @@ type Game struct {
 	  TeamB         *Team
 	  QuestionFile  *quiz.QuestionFile
 	  Active  	    bool
+	  LastActivity  time.Time
 	  mu            sync.Mutex
 }
 
@@ -40,7 +41,14 @@ func NewGame(questionFile *quiz.QuestionFile) *Game {
         TeamB: &Team{Players: []*Player{}, Name: "B-squad", Turn: 0},
         QuestionFile: questionFile,
         Active: false,
+        LastActivity: time.Now(),
     }
+}
+
+func (g *Game) UpdateActivity() {
+    g.mu.Lock()
+    defer g.mu.Unlock()
+    g.LastActivity = time.Now()
 }
 
 // Snapshot & Display
@@ -97,7 +105,14 @@ func (g *Game) TeamBroadcast(msg types.Envelope, t *Team) {
     }
 }
 
+func (g *Game) IsStale(threshold time.Duration) bool {
+    g.mu.Lock()
+    defer g.mu.Unlock()
+    return time.Since(g.LastActivity) > threshold
+}
+
 func (g *Game) PlayerBroadcast(msg types.Envelope, p *Player) {
+    g.UpdateActivity()
     data, _ := json.Marshal(msg)
     var logString = "🟦🔉↗️  Broadcast following Message to "+p.Name
     utils.LogPrettyJSON(logString, msg)
@@ -131,10 +146,10 @@ func (g *Game) AddPlayer(conn *websocket.Conn, name string) *Player {
 
 	player := NewPlayer(conn, name)
     if len(g.TeamB.Players) <  len(g.TeamA.Players) {
-		 log.Println("%s to team A: ", name)
+		 log.Printf("%s to team A: ", name)
          g.TeamB.AddPlayer(player)
     } else {
-		 log.Println("%s to team B: ", name)
+		 log.Printf("%s to team B: ", name)
         g.TeamA.AddPlayer(player)
     }
 	return player

--- a/game-server/internal/game/manager.go
+++ b/game-server/internal/game/manager.go
@@ -2,6 +2,7 @@ package game
 
 import (
     "sync"
+    "time"
     "flip-cup/internal/quiz" 
 	"flip-cup/internal/utils"
 	"fmt"
@@ -55,5 +56,35 @@ func (gm *GameManager) DeleteGameByID(id string) error {
 
     delete(gm.games, id)
     return nil
+}
+
+func (gm *GameManager) GetStaleGames(maxAge time.Duration) []*Game {
+    gm.mu.Lock()
+    defer gm.mu.Unlock()
+    stale := []*Game{}
+    for _, g := range gm.games {
+        if g.IsStale(maxAge) {
+            stale = append(stale, g)
+        }
+    }
+    return stale
+}
+
+func (gm *GameManager) CleanupStaleGames(maxAge time.Duration) {
+    gm.mu.Lock()
+    defer gm.mu.Unlock()
+
+    count := 0
+    for id, g := range gm.games {
+        // We use a small method on Game to safely check time
+        if g.IsStale(maxAge) {
+             fmt.Printf("🧹 Cleaning up stale game: %s\n", id)
+            delete(gm.games, id)
+            count++
+        }
+    }
+    if count > 0 {
+        fmt.Printf("🧹 Cleaned up %d stale games\n", count)
+    }
 }
 

--- a/game-server/internal/transport/api/games.go
+++ b/game-server/internal/transport/api/games.go
@@ -5,30 +5,38 @@ import (
 	"encoding/json"
 	"net/http"
 	"log"
+	"time"
 	"flip-cup/internal/game"
 	"github.com/gorilla/mux"
 )
 
 //
-// GET: /api/games/{active|inactive}
+// GET: /api/games/{active|inactive|stale}
 //
 func fetchGames(manager *game.GameManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)              // get path variables
-		status := vars["status"]         // "active" or "inactive"
+		status := vars["status"]         // "active" or "inactive" or "stale"
         var activeFilter *bool = nil
 
 
 		// Fetch all games from the manager
         log.Println("🎯 fetchGames called") 
-		games := manager.GetAllGames()
+		var games []*game.Game
 
+		if status == "stale" {
+			games = manager.GetStaleGames(30 * time.Minute)
+		} else {
+			games = manager.GetAllGames()
+		}
 
 		var response = []game.GameSnapshot{}
         if status == "active" {
             activeFilter = boolPtr(true)
         } else if status == "inactive" {
             activeFilter = boolPtr(false)
+        } else if status == "stale" {
+			// No extra filter needed, GetStaleGames already filtered
         } else {
 			// if you want, return 404 or 400 on invalid status
 			http.Error(w, "Invalid status", http.StatusBadRequest)
@@ -36,7 +44,9 @@ func fetchGames(manager *game.GameManager) http.HandlerFunc {
 		}
 
 		for _, g := range games {
-			if activeFilter == nil || g.Active == *activeFilter {
+			if status == "stale" {
+				response = append(response, g.Snapshot())
+			} else if activeFilter == nil || g.Active == *activeFilter {
 				response = append(response, g.Snapshot())
 			}
 		}


### PR DESCRIPTION
## Summary
Implements automated cleanup for stale games to manage server memory and state. Also adds an API endpoint to list stale games.

## Changes
- **Backend (`game-server`)**:
  - Added `LastActivity` timestamp to `Game` struct.
  - Implemented `IsStale(threshold)` logic.
  - Added `CleanupStaleGames` background routine (runs every 30m, removes games inactive >1h).
  - Updated `GET /games` endpoint to support `status=stale` filter.
- **Testing**:
  - Added unit tests in `internal/game/cleanup_test.go` verifying stale detection and removal.

## Verification
- Verified with new Go unit tests: `go test -v ./internal/game`