### PR TITLE
Update game-over cup layout and tests

### DIFF
--- a/ui/e2e/game-over-scenarios.spec.ts
+++ b/ui/e2e/game-over-scenarios.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import { answerIfMyTurn, createGame, getLobbyGameId, joinExistingGame, joinLobby } from './helpers/game';
+
+type TeamKey = 'A' | 'B';
+
+type Participant = {
+  name: string;
+  context: BrowserContext;
+  page: Page;
+  assignedTeam?: TeamKey;
+};
+
+const TEAM_A_NAME = 'A-Team';
+const TEAM_B_NAME = 'B-squad';
+const TEAM_SIZE = 5;
+const LOSING_TEAM_SCENARIOS = [1, 2, 3, 4] as const;
+
+function buildParticipantPlan(): { name: string }[] {
+  return Array.from({ length: TEAM_SIZE }, (_, index) => [
+    { name: `Alpha ${index + 1}` },
+    { name: `Bravo ${index + 1}` },
+  ]).flat();
+}
+
+async function setupFiveVsFiveGame(browser: Browser): Promise<Participant[]> {
+  const plan = buildParticipantPlan();
+  const contexts = await Promise.all(plan.map(() => browser.newContext()));
+  const pages = await Promise.all(contexts.map((context) => context.newPage()));
+
+  const participants = plan.map((player, index) => ({
+    ...player,
+    context: contexts[index],
+    page: pages[index],
+  }));
+
+  await createGame(participants[0].page);
+  const gameId = await getLobbyGameId(participants[0].page);
+  expect(gameId).toBeTruthy();
+
+  await Promise.all(participants.slice(1).map(({ page }) => joinExistingGame(page, gameId)));
+  await Promise.all(participants.map(({ page, name }) => joinLobby(page, name)));
+
+  await participants[0].page.getByRole('button', { name: /Mix Teams/i }).click();
+  await participants[0].page.waitForTimeout(1_000);
+
+  const startButton = participants[0].page.getByRole('button', { name: /Rack Cups & Start/i });
+  await expect(startButton).toBeEnabled({ timeout: 5_000 });
+  await startButton.click();
+
+  await Promise.all(
+    participants.map(({ page }) => expect(page.locator('.game-board')).toBeVisible({ timeout: 10_000 })),
+  );
+
+  await assignRuntimeTeams(participants);
+
+  return participants;
+}
+
+async function closeParticipants(participants: Participant[]): Promise<void> {
+  await Promise.all(participants.map(({ context }) => context.close()));
+}
+
+async function assignRuntimeTeams(participants: Participant[]): Promise<void> {
+  for (const participant of participants) {
+    const gameBoard = participant.page.locator('.game-board');
+    const className = await gameBoard.getAttribute('class');
+
+    if (className?.includes('team-a-view')) {
+      participant.assignedTeam = 'A';
+      continue;
+    }
+
+    if (className?.includes('team-b-view')) {
+      participant.assignedTeam = 'B';
+      continue;
+    }
+
+    throw new Error(`Could not resolve team assignment for ${participant.name}`);
+  }
+}
+
+function getTeamParticipants(participants: Participant[], team: TeamKey): Participant[] {
+  return participants.filter((participant) => participant.assignedTeam === team);
+}
+
+async function playScenario(
+  winningTeamPlayers: Participant[],
+  losingTeamPlayers: Participant[],
+  losingTeamCorrectAnswers: number,
+): Promise<void> {
+  const allParticipants = [...winningTeamPlayers, ...losingTeamPlayers];
+  let losingTeamCorrectCount = 0;
+
+  for (let tick = 0; tick < 160; tick++) {
+    if (await isGameOver(allParticipants)) {
+      return;
+    }
+
+    let progressed = false;
+
+    for (const participant of winningTeamPlayers) {
+      if (await answerIfMyTurn(participant.page)) {
+        progressed = true;
+        break;
+      }
+    }
+
+    if (losingTeamCorrectCount < losingTeamCorrectAnswers) {
+      for (const participant of losingTeamPlayers) {
+        if (await answerIfMyTurn(participant.page)) {
+          losingTeamCorrectCount += 1;
+          progressed = true;
+          break;
+        }
+      }
+    }
+
+    if (!progressed) {
+      await allParticipants[0].page.waitForTimeout(200);
+    }
+  }
+
+  throw new Error(`Game did not finish while validating losing team with ${losingTeamCorrectAnswers} correct answers`);
+}
+
+async function isGameOver(participants: Participant[]): Promise<boolean> {
+  for (const { page } of participants) {
+    if (await page.locator('.game-over').isVisible()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function teamSection(page: Page, teamName: string) {
+  return page.locator('.game-over-team').filter({
+    has: page.locator('.game-over-team-name', { hasText: teamName }),
+  });
+}
+
+async function expectTeamCupState(page: Page, teamName: string, flipped: number, filled: number, names: string[]): Promise<void> {
+  const section = teamSection(page, teamName);
+  await expect(section).toHaveCount(1);
+  await expect(section.locator('.game-over-cup.flipped')).toHaveCount(flipped);
+  await expect(section.locator('.game-over-cup.filled')).toHaveCount(filled);
+
+  for (const name of names) {
+    await expect(section.getByText(name, { exact: true })).toBeVisible();
+  }
+}
+
+test.describe('Game over cup scenarios', () => {
+  test.setTimeout(120_000);
+
+  for (const losingTeamCorrectAnswers of LOSING_TEAM_SCENARIOS) {
+    test(`5v5 game shows ${losingTeamCorrectAnswers} losing cups flipped when Team A wins`, async ({ browser }) => {
+      const participants = await setupFiveVsFiveGame(browser);
+
+      try {
+        const teamAPlayers = getTeamParticipants(participants, 'A');
+        const teamBPlayers = getTeamParticipants(participants, 'B');
+        expect(teamAPlayers).toHaveLength(TEAM_SIZE);
+        expect(teamBPlayers).toHaveLength(TEAM_SIZE);
+
+        await playScenario(teamAPlayers, teamBPlayers, losingTeamCorrectAnswers);
+
+        const teamAPage = teamAPlayers[0].page;
+        const teamBPage = teamBPlayers[0].page;
+        const teamAPlayerNames = teamAPlayers.map(({ name }) => name);
+        const teamBPlayerNames = teamBPlayers.map(({ name }) => name);
+
+        await expect(teamAPage.locator('.game-over')).toBeVisible();
+        await expect(teamBPage.locator('.game-over')).toBeVisible();
+        await expect(teamAPage.locator('.game-over-winner')).toHaveText('You ran the table!');
+        await expect(teamBPage.locator('.game-over-winner')).toHaveText(`${TEAM_A_NAME} ran the table`);
+
+        for (const page of [teamAPage, teamBPage]) {
+          await expect(page.locator('.game-over-cup-name')).toHaveCount(TEAM_SIZE * 2);
+          await expectTeamCupState(page, TEAM_A_NAME, TEAM_SIZE, 0, teamAPlayerNames);
+          await expectTeamCupState(
+            page,
+            TEAM_B_NAME,
+            losingTeamCorrectAnswers,
+            TEAM_SIZE - losingTeamCorrectAnswers,
+            teamBPlayerNames,
+          );
+        }
+      } finally {
+        await closeParticipants(participants);
+      }
+    });
+  }
+});

--- a/ui/e2e/game.spec.ts
+++ b/ui/e2e/game.spec.ts
@@ -1,78 +1,5 @@
 import { test, expect, type Page, type BrowserContext } from '@playwright/test';
-import { DEFAULT_QUIZ_ANSWERS } from './answers';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Create a game as player 1 and return to the lobby page. */
-async function createGame(page: Page): Promise<void> {
-  await page.goto('/');
-  await page.getByRole('button', { name: /Create New Game/i }).click();
-  await expect(page.locator('#qs-select')).toBeVisible();
-
-  // Select "General Quiz Set 1" (_.default) — first real option
-  await page.locator('#qs-select').selectOption({ index: 1 });
-  await page.locator('.submit-btn').click();
-
-  // Should land in lobby
-  await expect(page.locator('.lobby-icon')).toBeVisible();
-}
-
-/** Read the Game ID from the lobby. */
-async function getLobbyGameId(page: Page): Promise<string> {
-  const el = page.locator('.game-code-value');
-  await expect(el).toBeVisible();
-  return (await el.textContent()) ?? '';
-}
-
-/** Enter a player name and join the lobby. */
-async function joinLobby(page: Page, name: string): Promise<void> {
-  const input = page.locator('input[placeholder="Enter your name…"]');
-  await expect(input).toBeVisible();
-  await input.fill(name);
-  await page.getByRole('button', { name: /Join Game/i }).click();
-  await expect(page.getByRole('heading', { name: /^Lobby$/i })).toBeVisible({ timeout: 8_000 });
-  await expect(page.getByText(new RegExp(`You're in as\\s+${name}`, 'i'))).toBeVisible({ timeout: 8_000 });
-}
-
-/** Join an existing game from the Join screen. */
-async function joinExistingGame(page: Page, gameId: string): Promise<void> {
-  await page.goto('/');
-  await page.getByRole('button', { name: /Join Existing Game/i }).click();
-
-  // Wait for game cards to load
-  await expect(page.locator('.game-card').first()).toBeVisible({ timeout: 10_000 });
-
-  // Click the card matching the game ID
-  const card = page.locator('.game-card', { hasText: gameId });
-  await expect(card).toBeVisible();
-  await card.click();
-
-  await expect(page.locator('.lobby-icon')).toBeVisible();
-}
-
-/**
- * Answer the question shown on `page` if it's that player's turn.
- * Returns true if an answer was submitted, false if it wasn't this player's turn.
- */
-async function answerIfMyTurn(page: Page): Promise<boolean> {
-  const questionCard = page.locator('.question-card');
-  const isVisible = await questionCard.isVisible();
-  if (!isVisible) return false;
-
-  // Read the question text
-  const questionText = (await page.locator('.question-text').textContent()) ?? '';
-
-  // Find the answer (exact match first, then try all known answers)
-  const answer = DEFAULT_QUIZ_ANSWERS[questionText.trim()] ?? Object.values(DEFAULT_QUIZ_ANSWERS)[0];
-
-  const input = page.locator('.answer-input');
-  await input.fill(answer);
-  await page.locator('.submit-btn').click();
-
-  return true;
-}
+import { answerIfMyTurn, createGame, getLobbyGameId, joinExistingGame, joinLobby } from './helpers/game';
 
 /**
  * Play through the entire game, alternating turns between page1 and page2.
@@ -165,6 +92,12 @@ test.describe('Full multiplayer game', () => {
     const anyGameOver =
       (await p1GameOver.isVisible()) || (await p2GameOver.isVisible());
     expect(anyGameOver).toBe(true);
+
+    const gameOverPage = (await p1GameOver.isVisible()) ? player1 : player2;
+    await expect(gameOverPage.locator('.game-over-team')).toHaveCount(2);
+    await expect(gameOverPage.locator('.game-over-cup-name')).toHaveCount(2);
+    await expect(gameOverPage.locator('.game-over-cup.flipped')).toHaveCount(1);
+    await expect(gameOverPage.locator('.game-over-cup.filled')).toHaveCount(1);
   });
 
   test('Play Again resets the game and returns to lobby', async () => {

--- a/ui/e2e/helpers/game.ts
+++ b/ui/e2e/helpers/game.ts
@@ -1,0 +1,54 @@
+import { expect, type Page } from '@playwright/test';
+import { DEFAULT_QUIZ_ANSWERS } from '../answers';
+
+export async function createGame(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.getByRole('button', { name: /Create New Game/i }).click();
+  await expect(page.locator('#qs-select')).toBeVisible();
+  await page.locator('#qs-select').selectOption({ index: 1 });
+  await page.locator('.submit-btn').click();
+  await expect(page.locator('.lobby-icon')).toBeVisible();
+}
+
+export async function getLobbyGameId(page: Page): Promise<string> {
+  const el = page.locator('.game-code-value');
+  await expect(el).toBeVisible();
+  return (await el.textContent()) ?? '';
+}
+
+export async function joinLobby(page: Page, name: string): Promise<void> {
+  const input = page.locator('input[placeholder="Enter your name…"]');
+  await expect(input).toBeVisible();
+  await input.fill(name);
+  await page.getByRole('button', { name: /Join Game/i }).click();
+  await expect(page.getByRole('heading', { name: /^Lobby$/i })).toBeVisible({ timeout: 8_000 });
+  await expect(page.getByText(new RegExp(`You're in as\\s+${name}`, 'i'))).toBeVisible({ timeout: 8_000 });
+}
+
+export async function joinExistingGame(page: Page, gameId: string): Promise<void> {
+  await page.goto('/');
+  await page.getByRole('button', { name: /Join Existing Game/i }).click();
+  await expect(page.locator('.game-card').first()).toBeVisible({ timeout: 10_000 });
+
+  const card = page.locator('.game-card', { hasText: gameId });
+  await expect(card).toBeVisible();
+  await card.click();
+
+  await expect(page.locator('.lobby-icon')).toBeVisible();
+}
+
+export async function answerIfMyTurn(page: Page, answer?: string): Promise<boolean> {
+  const questionCard = page.locator('.question-card');
+  if (!(await questionCard.isVisible())) {
+    return false;
+  }
+
+  const questionText = ((await page.locator('.question-text').textContent()) ?? '').trim();
+  const resolvedAnswer = answer ?? DEFAULT_QUIZ_ANSWERS[questionText] ?? Object.values(DEFAULT_QUIZ_ANSWERS)[0];
+
+  const input = page.locator('.answer-input');
+  await input.fill(resolvedAnswer);
+  await page.locator('.submit-btn').click();
+
+  return true;
+}

--- a/ui/src/components/GameView.svelte
+++ b/ui/src/components/GameView.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
   import { send } from '$lib/transport/socket';
   import { mode, currentQuestion, gameState, myTeam, me, winner } from '$lib/store';
+  import type { Team } from '$lib/models/Team';
 
   let currentAnswer = '';
+
+  const getClearedCupCount = (team: Team, winnerName: string | null) => {
+    if (winnerName && team.name === winnerName) {
+      return team.players.length;
+    }
+
+    return Math.min(team.turn, team.players.length);
+  };
 
   const submitAnswer = () => {
     if (!currentAnswer.trim()) return;
@@ -137,18 +146,46 @@
   <div class="game-over">
     <div class="game-over-card">
       {#if $myTeam && $winner === $myTeam.name}
-        <img src="/solo-cup.png" alt="" class="trophy trophy-cup" />
         <p class="game-over-label">Table cleared</p>
         <h2 class="game-over-winner">You ran the table!</h2>
       {:else if $myTeam}
-        <img src="/solo-cup.png" alt="" class="trophy trophy-cup loss" />
         <p class="game-over-label">Next round</p>
         <h2 class="game-over-winner">{$winner} ran the table</h2>
       {:else}
-        <img src="/solo-cup.png" alt="" class="trophy trophy-cup" />
         <p class="game-over-label">Winner</p>
         <h2 class="game-over-winner">{$winner} cleared the table</h2>
       {/if}
+
+      {#if $gameState}
+        <div class="game-over-table">
+          {#each [$gameState.teamA, $gameState.teamB] as team, teamIndex}
+            {@const clearedCupCount = getClearedCupCount(team, $winner)}
+            <section
+              class="game-over-team"
+              class:winner-team={team.name === $winner}
+              class:my-team={$myTeam?.name === team.name}
+            >
+              <div class="game-over-team-header">
+                <span class="game-over-team-name">{team.name}</span>
+                <span class="game-over-team-status">
+                  {team.name === $winner ? 'Table cleared' : `${team.turn} of ${team.players.length} cups cleared`}
+                </span>
+              </div>
+
+              <div class="game-over-cups" class:right={teamIndex === 1}>
+                {#each team.players as player, index}
+                  {@const flipped = index < clearedCupCount}
+                  <div class="game-over-cup-slot">
+                    <div class="cup game-over-cup" class:flipped class:filled={!flipped} title={player.name}></div>
+                    <span class="game-over-cup-name">{player.name}</span>
+                  </div>
+                {/each}
+              </div>
+            </section>
+          {/each}
+        </div>
+      {/if}
+
       <button class="restart-btn" on:click={resetGame}>
         Play Again
       </button>
@@ -455,6 +492,8 @@
   .cup {
     width: 44px;
     height: 44px;
+    position: relative;
+    overflow: hidden;
     background-image: url('/solo-cup.png');
     background-size: cover;
     background-repeat: no-repeat;
@@ -546,21 +585,6 @@
     to { opacity: 1; transform: scale(1); }
   }
 
-  .trophy {
-    margin-bottom: 0.75rem;
-  }
-
-  .trophy-cup {
-    width: 92px;
-    height: auto;
-    filter: drop-shadow(0 14px 24px rgba(220, 38, 38, 0.22));
-  }
-
-  .trophy-cup.loss {
-    transform: rotate(180deg);
-    opacity: 0.7;
-  }
-
   .game-over-label {
     font-size: 0.75rem;
     font-weight: 700;
@@ -578,7 +602,100 @@
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
+    margin-bottom: 1.5rem;
+  }
+
+  .game-over-table {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
     margin-bottom: 2rem;
+    text-align: left;
+  }
+
+  .game-over-team {
+    padding: 1rem 1.125rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--r-lg);
+    background: rgba(19, 24, 39, 0.58);
+  }
+
+  .game-over-team.winner-team {
+    border-color: rgba(251, 191, 36, 0.32);
+    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.08);
+  }
+
+  .game-over-team.my-team {
+    background: rgba(32, 19, 17, 0.72);
+  }
+
+  .game-over-team-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.9rem;
+  }
+
+  .game-over-team-name {
+    font-size: 0.9rem;
+    font-weight: 800;
+    color: #fff7ed;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  .game-over-team-status {
+    font-size: 0.78rem;
+    color: rgba(255, 237, 213, 0.72);
+  }
+
+  .game-over-cups {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+    justify-content: flex-start;
+  }
+
+  .game-over-cups.right {
+    justify-content: flex-end;
+  }
+
+  .game-over-cup-slot {
+    width: 68px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .game-over-cup {
+    width: 52px;
+    height: 52px;
+    filter: drop-shadow(0 8px 14px rgba(0, 0, 0, 0.28));
+  }
+
+  .game-over-cup.filled::after {
+    content: '';
+    position: absolute;
+    left: 10px;
+    right: 10px;
+    top: 8px;
+    height: 12px;
+    border-radius: 999px 999px 10px 10px;
+    background: linear-gradient(180deg, rgba(250, 204, 21, 0.92), rgba(217, 119, 6, 0.88));
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.18) inset,
+      0 0 0 1px rgba(120, 53, 15, 0.24);
+  }
+
+  .game-over-cup-name {
+    font-size: 0.76rem;
+    font-weight: 600;
+    color: rgba(255, 237, 213, 0.86);
+    text-align: center;
+    line-height: 1.25;
+    word-break: break-word;
   }
 
   .restart-btn {
@@ -596,5 +713,26 @@
   .restart-btn:hover {
     transform: translateY(-2px);
     box-shadow: 0 6px 22px rgba(220, 38, 38, 0.42);
+  }
+
+  @media (max-width: 640px) {
+    .game-over-card {
+      width: min(100% - 1.5rem, 560px);
+      padding: 2rem 1.25rem;
+    }
+
+    .game-over-winner {
+      font-size: 2rem;
+    }
+
+    .game-over-team-header {
+      flex-direction: column;
+      align-items: flex-start;
+      margin-bottom: 0.75rem;
+    }
+
+    .game-over-cups.right {
+      justify-content: flex-start;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- render the final game-over state as per-player cups for both teams
- show losing-team remaining cups upright with beer and player names under each cup
- add Playwright coverage for 5v5 end-state scenarios with 1, 2, 3, and 4 losing-team clears

## Testing
- cd ui && npm run build
- cd ui && npm run test:e2e -- game.spec.ts
- cd ui && npm run test:e2e -- game.spec.ts game-over-scenarios.spec.ts