### PR TITLE
Refresh project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,160 @@
 # FlipCup
 
-A multiplayer quiz game where teams compete by flipping cups—by answering questions correctly. Inspired by Flip Cup, minus the beers. 🥤😎
+FlipCup is a real-time multiplayer trivia game built with a Go backend and a Svelte frontend. Players join a shared lobby, get split into teams, and race through quiz questions over WebSockets until one side wins.
 
-## 🚀 Live Demo
+The repo now has enough moving parts that the README is best treated as a guided index: it should help you understand what is here, where to look next, and how the pieces fit together without forcing every detail into one page.
 
-Try it out here: https://flipcup.fly.dev
+## What is in this repo?
 
-## 🎯 Purpose
+At a high level, FlipCup is made of five main parts:
 
-This was a fun side project to explore Go and Svelte — my first functional project in either. It's still a work in progress, so be gentle with the feedback 😄. That said, all contributions and ideas are welcome!
+- `game-server/` — the Go backend that owns HTTP routes, WebSocket sessions, game state, question loading, and stale-game cleanup
+- `ui/` — the Svelte frontend that renders the lobby/game screens and talks to the backend over HTTP + WebSockets
+- `ui/e2e/` — Playwright coverage for the multiplayer flows
+- `deploy/` — staging deployment assets, currently centered on a Nomad job definition for the homelab Pi cluster
+- `docs/` — project guides for architecture, gameplay, development, testing, deployment, and AI-assisted work
 
-## 🛠 Project Overview
+Quick repo map:
+
 ```text
-├── game-server                      // houses backend Go game server
-│   ├── cmd
-│   │   └── flipcup                     -- entrypoint
-│   ├── internal
-│   │   ├── game                        -- game-domain model/game-play files (game, team, player, etc)
-│   │   ├── quiz                        -- quiz-domain models 
-│   │   ├── transport                   -- http routing for rest endpoints and websocket handler for game play
-│   │   │   ├── api
-│   │   │   ├── types
-│   │   │   └── ws
-│   │   └── utils
-│   ├── public                          -- for single container deployments stores ui build
-│   └── questions                       -- stores all question yaml files
-└── ui                              // houses Svelte-kit frontend app
-    ├── public
-    └── src
-        ├── assets
-        │   └── fonts
-        ├── components
-        ├── lib
-        │   ├── models
-        │   ├── transport
-        │   │   └── http
-        │   ├── types
-        │   └── utils
-        └── styles
-
+.
+├── game-server/                # Go service, websocket/game logic, quiz loading
+├── ui/                         # Svelte client
+├── deploy/nomad/              # Staging Nomad job definition
+├── docs/                      # Project guides and supporting docs
+├── docker-compose.yml         # Local full-stack dev entry point
+├── Dockerfile                 # Shared deployment image for staging / Fly
+├── fly.toml                   # Fly.io production config
+└── gameflow.md                # Message-level websocket/game flow reference
 ```
 
+## Documentation map
 
-## 🤖 AI-Assisted Development
+If you did not write most of this code, start here:
 
-Recent improvements to this project (UI redesign, E2E test suite) were built with the help of GitHub Copilot. A full breakdown of what was delegated, how decisions were made, and what changed lives here:
+- [`docs/architecture.md`](docs/architecture.md) — codebase tour and component responsibilities
+- [`docs/gameplay.md`](docs/gameplay.md) — the game lifecycle from lobby to winner, with links to protocol details
+- [`docs/development.md`](docs/development.md) — local setup, common workflows, and where to start debugging
+- [`docs/testing.md`](docs/testing.md) — backend, frontend, Playwright, and CI coverage
+- [`docs/deployment.md`](docs/deployment.md) — local Docker Compose, staging on the Pi/Nomad stack, and Fly production
+- [`docs/ai-approach.md`](docs/ai-approach.md) — how Copilot was used across implementation, testing, docs, and repo operations
+- [`gameflow.md`](gameflow.md) — lower-level WebSocket message flow reference
 
-👉 **[docs/ai-approach.md](docs/ai-approach.md)**
+## Components at a glance
 
-## 🧪 Testing
+### Game server
 
-We use [Playwright](https://playwright.dev/) for End-to-End (E2E) testing. The tests simulate real user interactions (creating games, joining, answering questions) to ensure the full stack works together.
+The backend is a Go service under `game-server/` using Gorilla Mux and Gorilla WebSocket. It serves the API, upgrades `/ws` connections, manages game state in memory, loads quiz YAML, and handles cleanup of stale games.
 
-GitHub Actions now runs the test pipeline on every push and pull request. The first-pass required check for protecting `main` is `tests`, and `main` should be configured to only accept changes through pull requests after that check passes.
+Start with:
 
-### Prerequisites
+- `game-server/cmd/flipcup/`
+- `game-server/internal/game/`
+- `game-server/internal/transport/`
 
-Playwright now starts the backend and frontend automatically when you run the E2E suite, so the manual startup flow below is mainly useful for interactive local development.
+### UI
 
-If you want to run the app by hand, ensure both the backend and frontend are running locally:
+The frontend lives in `ui/` and is built with Svelte + Vite. It renders the welcome flow, lobby, active game, reconnect state, and endgame screens while deriving the runtime HTTP/WS host from either `VITE_WS_URL` or the current browser host.
 
-1.  **Start the Backend**:
-    ```bash
-    cd game-server
-    go run cmd/flipcup/main.go
-    ```
-2.  **Start the Frontend**:
-    ```bash
-    cd ui
-    npm install
-    npm run dev
-    ```
+Start with:
 
-### Running Tests
+- `ui/src/components/`
+- `ui/src/lib/`
+- `ui/src/lib/utils/config.ts`
 
-Run all tests:
+### Tests
+
+There are three practical layers of validation:
+
+- Go unit/integration tests under `game-server/`
+- frontend production build validation in `ui/`
+- Playwright end-to-end tests in `ui/e2e/`
+
+GitHub Actions runs the same test pipeline on pushes and pull requests. See [`docs/testing.md`](docs/testing.md) for the suite breakdown.
+
+### Deployments and environments
+
+FlipCup currently has three important environments:
+
+- local development via `docker-compose.yml`
+- staging on a Raspberry Pi homelab using a self-hosted GitHub runner, Nomad, Consul, Traefik, and Vault-backed runtime config
+- production on Fly.io via `fly.toml`
+
+The repo-root `Dockerfile` is the shared deployment image for staging and Fly. Local Compose does **not** use that file; it builds the backend from `game-server/` and the frontend from `ui/`, both in dev mode.
+
+See [`docs/deployment.md`](docs/deployment.md) for the environment-by-environment story.
+
+## Quick start
+
+### Local full stack with Docker Compose
+
+```bash
+docker-compose up -d
+```
+
+That starts:
+
+- the Go server on `http://localhost:8080`
+- the Svelte dev server on `http://localhost:5173`
+
+### Run the apps directly
+
+Backend:
+
+```bash
+cd game-server
+go run cmd/flipcup/main.go
+```
+
+Frontend:
+
 ```bash
 cd ui
-npx playwright test
+npm install
+npm run dev
 ```
 
-Run a specific test file (e.g., disconnection logic):
+## Testing commands
+
+Backend tests:
+
 ```bash
-npx playwright test e2e/disconnect.spec.ts
+cd game-server
+go test ./...
 ```
 
-Run tests with a visual UI (great for debugging):
+Frontend build:
+
 ```bash
-npx playwright test --ui
+cd ui
+npm ci
+npm run build
 ```
 
-### Writing Tests
+Playwright:
 
-Tests are located in `ui/e2e/`. To add a new test:
-1.  Create a file like `ui/e2e/my-feature.spec.ts`.
-2.  Import `test` and `expect` from `@playwright/test`.
-3.  Use `page` fixtures to interact with the game.
+```bash
+cd ui
+npx playwright install --with-deps chromium
+npm run test:e2e
+```
 
-**Note**: We use `sessionStorage` for player state, allowing you to simulate multiple players in a single browser instance by using different `BrowserContext`s. See `e2e/disconnect.spec.ts` for an example of multi-player testing.
+More detail on what these actually cover lives in [`docs/testing.md`](docs/testing.md).
 
-## 🤝 Contributing
-Got feedback, ideas, or issues? Open an issue or a pull request — would love to hear what you think! Lastly, for the record, no i was not in a frat. 
+## AI-assisted development
+
+This project includes a meaningful amount of GitHub Copilot-assisted work: UI redesign, reconnect handling, stale-game cleanup, Playwright coverage, GitHub Actions wiring, staging deployment setup, and documentation updates.
+
+The detailed write-up is in [`docs/ai-approach.md`](docs/ai-approach.md).
+
+## Contributing / navigating
+
+If you are exploring the codebase for the first time:
+
+1. read [`docs/architecture.md`](docs/architecture.md)
+2. skim [`docs/gameplay.md`](docs/gameplay.md)
+3. use [`docs/development.md`](docs/development.md) for local setup
+4. use [`docs/testing.md`](docs/testing.md) before changing behavior
+5. use [`docs/deployment.md`](docs/deployment.md) before touching staging or Fly
+
+And yes, for the record: no, this project did not require being in a frat.

--- a/docs/ai-approach.md
+++ b/docs/ai-approach.md
@@ -1,21 +1,26 @@
 # AI-Assisted Development Approach
 
-This document explains how GitHub Copilot was used to ship the work that landed in [PR #6](https://github.com/richvigorito/flip-cup/pull/6): a frontend redesign, reconnect hardening, stale-game cleanup, expanded E2E coverage, CI automation, and the PR artifacts themselves.
+This document explains how GitHub Copilot has been used in FlipCup, both for the original product work and for later engineering/operations work around testing, deployment, and documentation.
 
 ## Overview
 
-The important detail is that Copilot was not only used to generate code. It was also used to:
+The important detail is that Copilot was not only used to generate code. Across the project it has also been used to:
 
-- inspect the codebase and identify weaknesses
-- propose and implement the redesign
-- patch frontend and backend logic needed to support the redesign safely
-- write the Playwright coverage used to verify the changes
-- generate the before/after screenshots included in the PR
-- draft and update the PR summary/comments during review
+- inspect the codebase and identify weak spots
+- implement UI and backend changes
+- write and debug Playwright coverage
+- wire GitHub Actions workflows
+- help shape staging deployment on the homelab
+- document architecture, deployment, and repo usage
+- draft PR bodies, follow-up explanations, and review artifacts
 
-In other words, the code changes, the PR body and follow-up comments, and the screenshot comparison workflow were all produced through a Copilot-led, agentic workflow.
+In other words, the AI contribution in this repo has been broader than "generated a few files." It has included implementation, validation, ops wiring, and project documentation.
 
-## What PR #6 actually shipped
+## The original major Copilot-assisted push: PR #6
+
+The first major documented Copilot-led wave landed in [PR #6](https://github.com/richvigorito/flip-cup/pull/6): a frontend redesign, reconnect hardening, stale-game cleanup, expanded E2E coverage, CI automation, and the PR artifacts themselves.
+
+### What PR #6 actually shipped
 
 Although the branch started as a UI redesign, the merged PR ended up covering more than styling.
 
@@ -31,7 +36,9 @@ Although the branch started as a UI redesign, the merged PR ended up covering mo
 
 That broader scope matters because it shows how the AI workflow evolved: a design prompt surfaced product and reliability issues that then got fixed in the same branch.
 
-## Step 1 — Audit first, then build
+## How that work was approached
+
+### 1. Audit first, then build
 
 Before implementation, Copilot was used to explore the repo, read the game flow, inspect the WebSocket path, and identify the most obvious gaps.
 
@@ -44,40 +51,38 @@ The audit surfaced a few themes:
 
 That audit effectively became the backlog for the PR.
 
-## Step 2 — Frontend redesign
-
-The initial user request was essentially: make the UI look much cleaner.
+### 2. Frontend redesign
 
 Copilot then drove the redesign across the Svelte app:
 
 - introduced a more coherent design system with CSS custom properties
-- replaced the older basic screens with card-based layouts and stronger visual hierarchy
+- replaced older basic screens with card-based layouts and stronger visual hierarchy
 - improved `Welcome`, `NewGame`, `JoinGame`, `Lobby`, `GameView`, `EventLog`, and `Instructions`
 - added a more opinionated game presentation, including team-specific perspective and richer game-over states
 
 Most of the visual direction was chosen autonomously by Copilot. The user did not specify a detailed design system, component map, or animation spec ahead of time.
 
-## Step 3 — Reliability work discovered during implementation
+### 3. Reliability work discovered during implementation
 
-As the redesign was integrated, Copilot also patched issues that directly affected the experience:
+As the redesign was integrated, Copilot also patched issues that directly affected the experience.
 
-### Reconnect and session continuity
+#### Reconnect and session continuity
 
 On the frontend, the socket flow was updated so game/player identity survives reloads per browser tab using `sessionStorage` instead of `localStorage`. That was especially useful for testing multi-player flows in parallel tabs/contexts.
 
 The frontend state layer was also adjusted to derive `myTeam` from `gameState` plus `me`, which fixed cases where a reconnecting player could render the wrong team perspective.
 
-### Backend stale-game cleanup
+#### Backend stale-game cleanup
 
 On the Go side, the `Game` model gained `LastActivity` tracking plus helper methods such as `UpdateActivity()` and `IsStale()`. `GameManager` then added stale-game discovery and cleanup helpers so long-dead games can be removed automatically instead of accumulating forever.
 
 This is a good example of Copilot going beyond the visible UI task and handling adjacent operational issues uncovered during the work.
 
-## Step 4 — Testing and CI
+### 4. Testing and CI
 
 Copilot also built the verification story around the PR.
 
-### Playwright coverage
+#### Playwright coverage
 
 The project already had the basic gameplay E2E suite by the end of this work, and PR #6 extended that with reconnect coverage in `ui/e2e/disconnect.spec.ts`.
 
@@ -90,18 +95,53 @@ That reconnect test:
 - verifies the player returns to the active game instead of dropping back to a cold start
 - checks the board still renders with the correct team-specific view
 
-### GitHub Actions
+#### GitHub Actions
 
-Copilot also added `.github/workflows/ci.yml`, which runs:
+Copilot also added the CI workflow that runs:
 
 - `go test ./...`
 - `npm ci`
 - `npm run build`
 - `npm run test:e2e`
 
-That turned the PR from "looks better" into "looks better and is validated end-to-end."
+That turned the project from "looks better" into "looks better and is validated end-to-end."
 
-## Screenshots from the PR
+## Later Copilot-assisted work beyond PR #6
+
+The repo has since used Copilot for more than the original redesign branch.
+
+### Documentation and repo explainability
+
+Copilot has been used to:
+
+- rewrite the README into a repo index
+- add docs for architecture, gameplay, development, testing, and deployment
+- turn deployment tribal knowledge into documented staging/Fly guidance
+
+That matters because the project now has enough moving parts that explainability is part of maintainability.
+
+### Staging deployment and homelab operations
+
+Copilot has also been used to:
+
+- wire a self-hosted GitHub Actions runner into the homelab
+- update the staging Nomad job to use Vault-backed runtime config
+- document the relationship between the runner, Nomad, Traefik, and Vault
+- debug workflow failures around missing reusable workflows, Docker permissions, and missing deployment artifacts
+
+This is a different class of work than UI generation. It is closer to "developer operations assistant" than "code completion."
+
+### PR operations and workflow repair
+
+Copilot has also been useful for:
+
+- drafting PR bodies
+- tracking required checks / ruleset mismatches
+- creating focused follow-up PRs
+- debugging GitHub Actions runs by reading check runs and logs
+- keeping docs aligned with what is actually deployed
+
+## Screenshots from the redesign work
 
 The PR included a before/after screenshot comparison, and those screenshots were also produced via Copilot.
 
@@ -114,28 +154,15 @@ Copilot generated the capture workflow, used Playwright-based screenshot automat
 | Lobby | ![Legacy Lobby](./screenshots/before/03_lobby_empty.png) | ![Redesigned Lobby](./screenshots/after/03_lobby_empty.png) |
 | Game View | ![Legacy Game View](./screenshots/before/06_game_view_team_b.png) | ![Redesigned Game View](./screenshots/after/06_game_view_team_b.png) |
 
-Those images are useful because they show the practical output of the workflow, not just the code behind it.
-
-## PR operations handled with Copilot
-
-One of the more interesting parts of PR #6 is that Copilot was used for the operational work around the code as well:
-
-- drafting the PR body itself
-- updating the PR summary as scope changed
-- documenting follow-up fixes requested during review
-- resolving merge conflicts against `main` while preserving the redesign
-- verifying the build after conflict resolution
-
-That means the AI contribution was not limited to a one-shot code generation phase. It stayed involved through implementation, review, conflict resolution, verification, and documentation.
-
 ## What worked well
 
 - Starting with exploration gave Copilot enough context to make better changes.
 - Keeping Playwright involved made it easier to safely change a multiplayer WebSocket flow.
-- Using AI for both implementation and PR hygiene reduced the handoff friction between "write code" and "explain what changed."
+- Using AI for implementation, testing, PR hygiene, and documentation reduced handoff friction.
+- Using the same assistant for both code and ops/debug loops was especially useful once staging deployment got more complex.
 
 ## What to watch
 
-- The screenshot comparisons are only as good as the scripted capture flow; if screens change significantly, the capture scripts and artifacts need refreshing.
-- The reconnect logic depends on the current client/server message contract staying stable.
-- This workflow was strong for UI polish plus targeted reliability fixes, but it still benefits from human review for surprising changes or scope creep.
+- The screenshot comparisons are only as good as the scripted capture flow; if screens change significantly, the artifacts need refreshing.
+- Reconnect logic depends on the current client/server message contract staying stable.
+- AI is very useful for momentum and coverage here, but human review is still important for scope control and for catching subtle behavior changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,124 @@
+# Architecture guide
+
+This is the high-level codebase tour for FlipCup. If you did not write most of the project, this should give you the "what lives where?" map before you dive into implementation details.
+
+## The big picture
+
+FlipCup is a real-time multiplayer trivia app with:
+
+- a Go backend for HTTP, WebSockets, game state, and quiz loading
+- a Svelte frontend for the lobby/game UI
+- Playwright coverage for multiplayer browser flows
+- a shared deployment image for staging and Fly
+
+The app currently keeps game state in memory, which explains a lot of the deployment choices:
+
+- staging runs as a single Nomad allocation
+- Fly should stay conservative about scaling
+- reconnect behavior matters because deploys and browser refreshes can interrupt live sessions
+
+## Codebase layout
+
+### `game-server/`
+
+This is the backend application.
+
+Important areas:
+
+- `cmd/flipcup/` — the executable entrypoint
+- `internal/game/` — core game models and lifecycle logic
+- `internal/quiz/` — quiz loading and domain logic
+- `internal/transport/api/` — HTTP endpoints
+- `internal/transport/ws/` — WebSocket handling
+- `questions/` — YAML quiz content
+- `public/` — built frontend assets used by the single-container deploy image
+
+The backend is responsible for:
+
+- creating and joining games
+- assigning teams
+- tracking active player/question flow
+- broadcasting events over WebSockets
+- handling reconnects and stale cleanup
+
+### `ui/`
+
+This is the frontend application built with Svelte + Vite.
+
+Important areas:
+
+- `src/components/` — major screens and UI components
+- `src/lib/` — stores, helpers, and shared utilities
+- `src/lib/utils/config.ts` — runtime host/URL resolution for HTTP and WebSocket traffic
+- `e2e/` — Playwright tests
+
+The frontend is responsible for:
+
+- creating/joining games
+- rendering the lobby and team state
+- rendering the active game view
+- reconnecting players to the correct game context
+- surfacing winner/endgame state
+
+### `deploy/`
+
+This currently exists for staging.
+
+- `deploy/nomad/flipcup.nomad.hcl` defines the staging job for the homelab Pi cluster
+
+That job:
+
+- runs a single service allocation
+- uses a task-level Vault integration
+- renders env vars from Vault into the app task
+- registers the service for Traefik/Consul routing
+
+### `docs/`
+
+This directory holds the human-oriented guides:
+
+- architecture
+- gameplay
+- development
+- testing
+- deployment
+- AI-assisted development notes
+
+### Root-level infrastructure files
+
+- `docker-compose.yml` — local full-stack dev
+- `Dockerfile` — shared deployment image for staging/Fly
+- `fly.toml` — Fly.io production configuration
+- `gameflow.md` — protocol-level message flow reference
+
+## How requests and events move through the app
+
+At a high level:
+
+1. the browser hits the UI
+2. the UI opens a WebSocket to `/ws`
+3. the backend creates/loads in-memory game state
+4. gameplay events are broadcast back to connected players
+5. the UI updates from that state stream
+
+For the detailed event reference, read [`../gameflow.md`](../gameflow.md).
+
+## Good starting points by task
+
+If you are fixing or adding something:
+
+- lobby/game lifecycle bug — `game-server/internal/game/`
+- API/WebSocket bug — `game-server/internal/transport/`
+- UI/state issue — `ui/src/components/`, `ui/src/lib/`
+- reconnect behavior — `ui/src/lib/`, `ui/e2e/disconnect.spec.ts`, backend transport/game files
+- stale cleanup or timers — `game-server/internal/game/`
+- staging deploy issue — `deploy/nomad/flipcup.nomad.hcl`, `.github/workflows/deploy-staging.yml`, [`deployment.md`](deployment.md)
+
+## Constraints worth keeping in mind
+
+- game state is in memory, so multiple replicas are not a free win
+- WebSocket stability matters more than aggressive autoscaling
+- local development is intentionally simple and should stay simple
+- staging is intentionally close to production packaging, but runs inside the homelab
+
+If you want the practical "how do I run this and work on it?" guide next, go to [`development.md`](development.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,72 +1,105 @@
 # Deployment guide
 
-## Environment contract
+This document explains the three environment stories in the repo:
 
-FlipCup now uses one production-oriented container build at the repository root (`Dockerfile`) and keeps environment differences in runtime configuration instead of separate packaging flows.
+- local development with Docker Compose
+- staging on the homelab Pi cluster
+- production on Fly.io
+
+The key design choice is that local development keeps its own dev-focused Dockerfiles, while staging and production share the repo-root deployment `Dockerfile`.
+
+## Environment contract
 
 | Environment | Packaging path | Frontend websocket config | Backend port |
 | --- | --- | --- | --- |
-| Local dev | `docker-compose.yml` with service-specific dev Dockerfiles | `VITE_WS_URL=localhost:8080` with runtime fallback to the current LAN host when opened from another device | `PORT=8080` |
-| Staging | Root `Dockerfile`, built on the staging Nomad host | Leave `VITE_WS_URL` unset so the UI uses the current host | `PORT=8080` |
-| Production | Root `Dockerfile`, pushed to Artifact Registry and deployed to Cloud Run | Leave `VITE_WS_URL` unset so the UI uses the current host | `PORT=8080` |
+| Local dev | `docker-compose.yml` with `game-server/Dockerfile` and `ui/Dockerfile` dev targets | `VITE_WS_URL=localhost:8080` for the frontend dev server | `PORT=8080` |
+| Staging | repo-root `Dockerfile`, built by the self-hosted runner on the staging Pi | leave `VITE_WS_URL` unset so the browser host is used at runtime | `PORT` comes from Nomad |
+| Production | repo-root `Dockerfile`, deployed through Fly using `fly.toml` | leave `VITE_WS_URL` unset so the browser host is used at runtime | `PORT=8080` |
 
-The frontend local override now lives in `ui/.env.development`. That keeps `localhost:8080` out of production Vite builds while still letting remote devices on the same LAN connect through the browser's current host.
+The frontend runtime host logic lives in `ui/src/lib/utils/config.ts`, which is why staging and Fly can rely on the current host instead of baking in a hardcoded deployment URL.
 
 ## Local development
 
-Use Docker Compose for the quickest full-stack loop:
+For the quickest full-stack loop:
 
 ```bash
 docker-compose up -d
 ```
 
-You can also work in each app directly:
+Compose uses:
+
+- `game-server/Dockerfile` with target `dev`
+- `ui/Dockerfile` with target `dev`
+
+That means the repo-root deployment `Dockerfile` does **not** interfere with the local developer workflow.
+
+You can also run each app directly:
 
 ```bash
 cd game-server && go run cmd/flipcup/main.go
 cd ui && npm install && npm run dev
 ```
 
-## Staging on Nomad / Consul / Traefik
+## Staging on Nomad / Consul / Traefik / Vault
 
-The staging job definition lives at `deploy/nomad/flipcup.nomad.hcl`.
+The staging job definition lives at:
 
-Key assumptions:
+- `deploy/nomad/flipcup.nomad.hcl`
 
-- staging runs a single FlipCup allocation until the app has shared state
-- the allocation is pinned to one Nomad node so the locally built image is available to the Docker driver
-- Traefik routes the `.homelab` host alias over the `web` entrypoint to the Nomad service registered in Consul
-- the app is exposed on `/` and `/ws` from the same hostname
+The staging deploy workflow lives at:
 
-The `Deploy staging` GitHub Actions workflow does the following after validation passes:
+- `.github/workflows/deploy-staging.yml`
 
-1. runs on a self-hosted GitHub Actions runner inside the homelab
-2. builds the root `Dockerfile` locally on that runner
-3. verifies Docker and the Nomad CLI are available and can reach the cluster
-4. runs `nomad job run` with the staging hostname and node variables
+### How staging deployment works
 
-Required GitHub configuration for the workflow:
+1. `Deploy staging` is triggered in GitHub Actions
+2. GitHub schedules the deploy job onto the self-hosted runner labeled `self-hosted`, `Linux`, `ARM64`, `staging`
+3. that runner is installed on the homelab staging node
+4. the runner checks out the repo, builds the repo-root `Dockerfile`, and runs `nomad job run`
+5. Nomad schedules the `flipcup` job on the pinned node
+6. the task reads its runtime config from Vault and starts behind Traefik
 
-- repository variable `STAGING_HOSTNAME`
-- optional variables `STAGING_NOMAD_DATACENTER`, `STAGING_NOMAD_NODE`
-- a self-hosted runner labeled `self-hosted`, `Linux`, `ARM64`, and `staging`
+Important detail: GitHub does **not** push into the home network directly. The self-hosted runner inside the homelab polls GitHub for jobs and executes them locally.
 
-Defaults in this repository assume the current Raspberry Pi cluster shape:
+### Key assumptions
+
+- staging runs one allocation because the app still keeps game state in memory
+- the job is pinned to one Nomad node so the locally built Docker image is available to the Docker driver
+- Traefik routes the chosen hostname to the Nomad service
+- the app is served from the same host for HTTP and WebSocket traffic
+
+### Required GitHub repository variables
+
+- `STAGING_HOSTNAME`
+- optional `STAGING_NOMAD_DATACENTER`
+- optional `STAGING_NOMAD_NODE`
+
+Current defaults used by the workflow:
 
 - `STAGING_NOMAD_DATACENTER=rv_homelab`
 - `STAGING_NOMAD_NODE=rv-hstack-node1-pi4`
 
-The self-hosted runner should live on the same node named by `STAGING_NOMAD_NODE`. The staging job still uses a locally built Docker image and is pinned to one Nomad node, so building and deploying from a different machine would leave the target node without the image unless you switch to a shared image registry.
+### Runner requirements
 
-Override those variables only if the cluster naming changes or you want the job pinned elsewhere.
+The staging runner should:
 
-FlipCup staging runtime settings are now sourced from Vault instead of Nomad Variables.
+- run inside the homelab
+- be registered on the repo with labels `self-hosted`, `Linux`, `ARM64`, `staging`
+- have working access to Docker and Nomad
+- ideally live on the same node named by `STAGING_NOMAD_NODE`
 
-The Nomad task authenticates to Vault with:
+That last point matters because the workflow builds the Docker image locally and then runs Nomad on the same host. If you move the runner elsewhere without introducing a shared image registry, Nomad may schedule onto a node that does not have the built image.
 
-- auth mount `auth/jwt-nomad`
-- role `flipcup-staging`
-- KV v2 secret read path `secret/data/flipcup/staging`
+### Vault-backed runtime config
+
+The staging task uses Nomad's native Vault integration.
+
+Current contract:
+
+- auth mount: `auth/jwt-nomad`
+- role: `flipcup-staging`
+- secret read path in templates: `secret/data/flipcup/staging`
+- logical write path for CLI usage: `secret/flipcup/staging`
 
 Seed the secret from a machine that already has Vault access:
 
@@ -74,66 +107,85 @@ Seed the secret from a machine that already has Vault access:
 vault kv put secret/flipcup/staging cleanup_interval=30m stale_after=1h
 ```
 
-The current job reads:
+Those values are rendered into:
 
-- `cleanup_interval` → `GAME_CLEANUP_INTERVAL`
-- `stale_after` → `GAME_STALE_AFTER`
+- `GAME_CLEANUP_INTERVAL`
+- `GAME_STALE_AFTER`
 
-`PORT` still comes from Nomad's allocated service port.
+### Staging verification checklist
 
-The template stanza reads the KV v2 API path `secret/data/flipcup/staging`, while the CLI command above writes to the logical path `secret/flipcup/staging`.
+After a deploy:
 
-## Production on Cloud Run
+```bash
+nomad status flipcup
+nomad job allocs flipcup
+nomad alloc status <alloc-id>
+nomad alloc logs <alloc-id>
+curl http://flipcup.homelab/quizzes
+```
 
-Terraform lives in `infra/terraform/cloud-run` and provisions:
+## Production on Fly.io
 
-- an Artifact Registry Docker repository
-- a Cloud Run service account
-- a public Cloud Run service for the FlipCup image
+Production is described here in Fly terms because the repo still contains a live Fly config:
 
-The production workflow validates the app, bootstraps Artifact Registry via Terraform, builds the root image, pushes it, and applies the full Cloud Run configuration.
+- `fly.toml`
 
-Required GitHub configuration:
+The Fly app name is:
 
-- secret `GCP_PROJECT_ID`
-- secret `GCP_WORKLOAD_IDENTITY_PROVIDER`
-- secret `GCP_DEPLOYER_SERVICE_ACCOUNT`
-- optional variable `GCP_REGION`
-- optional variable `GCP_ARTIFACT_REPOSITORY`
-- optional variable `GCP_CLOUD_RUN_SERVICE`
+- `flipcup`
 
-### Cloud Run websocket and state notes
+That means the default Fly hostname is typically:
 
-Cloud Run supports WebSockets, but they are still long-lived HTTP requests. For this app that means:
+- `https://flipcup.fly.dev`
 
-- request timeout is set to `3600s`
-- max instances stay at `1` so in-memory game state is not split across replicas
-- websocket clients should be expected to reconnect after deploys or request timeout boundaries
-- Cloud Run is not guaranteed to stay inside the free tier because active websocket connections keep the instance billable while they are open
+### Production packaging
 
-Those defaults intentionally favor correctness over aggressive autoscaling.
+Fly should build from the repo-root `Dockerfile`:
+
+```toml
+[build]
+  dockerfile = 'Dockerfile'
+```
+
+That keeps staging and production aligned around the same deployment image.
+
+### Production deploy shape
+
+At a high level:
+
+1. build the repo-root `Dockerfile`
+2. deploy it with Fly using `fly.toml`
+3. let the browser derive its HTTP/WS host from the deployed Fly domain
+
+Typical manual command:
+
+```bash
+fly deploy
+```
+
+### Fly-specific operational note
+
+Because FlipCup still keeps game state in memory, production should stay conservative:
+
+- prefer a single machine / single active instance unless shared state is added later
+- be careful with scaling and rolling restarts
+- expect WebSocket reconnects around deploy boundaries
 
 ## CI and deployment gates
 
-Validation is centralized in `.github/workflows/validate.yml` and reused by:
+Validation is defined in:
 
-- `CI` on every push and pull request
-- `Deploy staging`
-- `Deploy production`
+- `.github/workflows/ci.yml`
+- `.github/workflows/validate.yml`
 
-That keeps Playwright, UI build, and Go test coverage consistent across normal development and deployments.
+That validation is reused by staging deploys so changes get the same Go/UI/Playwright coverage before rollout.
 
 ## Protecting `main`
 
-Configure `main` in GitHub branch protection or rulesets with these minimum rules:
+At minimum, keep `main` protected by rules that:
 
-- require pull requests before merging
+- require pull requests
 - block direct pushes
-- require the `tests` status check from the `CI` workflow
-- optionally require approvals before merge
+- require the `tests` check from the `CI` workflow
 
-The workflows in this repo assume deployment happens only after code reaches `main` through that PR flow.
-
-## Legacy Fly.io support
-
-`fly.toml` remains in the repository as an optional legacy target, but it now builds from the shared root `Dockerfile`. Cloud Run is the primary production path.
+That keeps staging deploys tied to code that has already passed the normal validation path.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,111 @@
+# Development guide
+
+This is the practical guide for running FlipCup locally and figuring out where to start when you want to change something.
+
+## Fastest local setup
+
+The quickest full-stack loop is Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+That uses:
+
+- `game-server/Dockerfile` with the `dev` target
+- `ui/Dockerfile` with the `dev` target
+
+Important: local Compose does **not** use the repo-root `Dockerfile`. That root image exists for deployment packaging, not for your normal inner loop.
+
+## Running the apps directly
+
+Backend:
+
+```bash
+cd game-server
+go run cmd/flipcup/main.go
+```
+
+Frontend:
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+Useful local URLs:
+
+- backend: `http://localhost:8080`
+- frontend: `http://localhost:5173`
+
+## Runtime host / WebSocket behavior
+
+The frontend runtime URL logic lives in:
+
+- `ui/src/lib/utils/config.ts`
+
+Behavior summary:
+
+- local dev usually uses `VITE_WS_URL=localhost:8080`
+- deployed environments can leave `VITE_WS_URL` unset
+- when unset, the UI falls back to the current browser host and builds HTTP/WS URLs from there
+
+That lets staging/Fly avoid hardcoding a specific deploy hostname into the frontend build.
+
+## Recommended reading order for new contributors
+
+If you are new to the repo:
+
+1. read [`architecture.md`](architecture.md)
+2. read [`gameplay.md`](gameplay.md)
+3. skim [`../gameflow.md`](../gameflow.md) if you are changing WebSocket behavior
+4. use [`testing.md`](testing.md) before changing anything risky
+
+## Common change entry points
+
+### Backend logic
+
+Start in:
+
+- `game-server/internal/game/`
+- `game-server/internal/quiz/`
+
+### API or WebSocket transport
+
+Start in:
+
+- `game-server/internal/transport/api/`
+- `game-server/internal/transport/ws/`
+
+### Frontend UI or state
+
+Start in:
+
+- `ui/src/components/`
+- `ui/src/lib/`
+
+### Deployment work
+
+Start in:
+
+- `deploy/nomad/flipcup.nomad.hcl`
+- `.github/workflows/deploy-staging.yml`
+- `Dockerfile`
+- `fly.toml`
+
+## A few practical cautions
+
+- game state is in memory, so be careful about assumptions around scaling or multiple replicas
+- if you touch reconnect logic, validate both frontend state and backend session handling
+- if you touch deployment packaging, make sure you are not accidentally changing local Compose behavior
+- if you touch gameplay, think through multiplayer side effects instead of only the happy path
+
+## What "local development" really means here
+
+There are two different workflows in this repo:
+
+- **developer workflow** — Docker Compose or direct app commands
+- **deployment workflow** — build the shared root `Dockerfile` for staging/Fly
+
+Keeping those separate is intentional. It preserves a fast dev loop while still letting staging and production share one deployable image.

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -1,0 +1,96 @@
+# Gameplay guide
+
+This document explains what the player flow is supposed to feel like and where that behavior lives in the codebase.
+
+If you need the lower-level message contract, use [`../gameflow.md`](../gameflow.md). This page is the friendlier overview.
+
+## Player journey
+
+The normal flow is:
+
+1. a player creates or joins a game
+2. players gather in the lobby
+3. the host assigns teams
+4. the host starts the game
+5. the active player answers the current question
+6. the server advances the game until one team wins
+7. players can restart into a new round
+
+## Lobby phase
+
+The lobby is where most session setup happens:
+
+- players join and pick names
+- the host waits for enough players
+- teams are assigned before the game starts
+
+If something feels off here, look at:
+
+- backend: `game-server/internal/game/`
+- transport: `game-server/internal/transport/ws/`
+- frontend: `ui/src/components/Lobby.svelte`
+
+## Active game phase
+
+Once the match starts:
+
+- the server tracks whose turn it is
+- the current player gets the question prompt
+- correct answers advance the team
+- incorrect answers broadcast feedback and preserve turn/game rules
+
+This is mostly coordinated through:
+
+- `game-server/internal/game/`
+- `game-server/internal/transport/ws/`
+- `ui/src/components/GameView*.svelte`
+
+## Reconnect and recovery
+
+Because this is a multiplayer WebSocket app, reconnect behavior matters.
+
+The current design tries to preserve enough client identity that a page refresh can reconnect the player to the right game instead of dumping them into a blank start screen.
+
+Useful places:
+
+- `ui/src/lib/`
+- `ui/e2e/disconnect.spec.ts`
+- backend game/session handling under `game-server/internal/`
+
+## Endgame
+
+When a team wins:
+
+- the backend emits a winner event
+- the UI renders the game-over state
+- players can start another round with a restart action
+
+Useful places:
+
+- `game-server/internal/game/`
+- `ui/src/components/`
+- `ui/e2e/game-over-scenarios.spec.ts`
+
+## Stale cleanup
+
+FlipCup also has cleanup logic for inactive in-memory games.
+
+That matters operationally because:
+
+- the server keeps state in memory
+- dead games should not accumulate forever
+- staging/ops workflows may want to trigger or rely on cleanup behavior
+
+Useful places:
+
+- `game-server/internal/game/cleanup.go`
+- related tests under `game-server/internal/game/`
+
+## If you need the protocol details
+
+Use [`../gameflow.md`](../gameflow.md) when you need:
+
+- exact message names
+- inbound vs outbound message direction
+- payload structure examples
+- the WebSocket event sequence

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,126 @@
+# Testing guide
+
+FlipCup uses a layered test strategy:
+
+- Go tests for backend behavior
+- frontend production build as a sanity check
+- Playwright for end-to-end multiplayer flows
+- GitHub Actions to run the same validation automatically
+
+## Backend tests
+
+Run:
+
+```bash
+cd game-server
+go test ./...
+```
+
+This is the main safety net for:
+
+- game state logic
+- cleanup behavior
+- API behavior
+- backend regressions that do not need a browser
+
+## Frontend build check
+
+Run:
+
+```bash
+cd ui
+npm ci
+npm run build
+```
+
+This is the fastest way to catch:
+
+- broken imports
+- type/build issues
+- Svelte/Vite bundling problems
+
+## End-to-end tests
+
+Run:
+
+```bash
+cd ui
+npx playwright install --with-deps chromium
+npm run test:e2e
+```
+
+Additional helpers:
+
+```bash
+cd ui
+npm run test:e2e:ui
+npm run test:e2e:report
+```
+
+The Playwright suite is the best safety net for:
+
+- multiplayer flows
+- reconnect behavior
+- screen-level regressions
+- "does the app actually work from the browser?" validation
+
+Key test locations:
+
+- `ui/e2e/game.spec.ts`
+- `ui/e2e/disconnect.spec.ts`
+- `ui/e2e/game-over-scenarios.spec.ts`
+- screenshot/spec helpers under `ui/e2e/`
+
+## CI
+
+The main CI workflow is:
+
+- `.github/workflows/ci.yml`
+
+The reusable validation workflow is:
+
+- `.github/workflows/validate.yml`
+
+Those workflows run:
+
+1. Go tests
+2. UI dependency install
+3. UI build
+4. Playwright browser install
+5. Playwright end-to-end tests
+
+That same validation pipeline is reused by staging deploys so deployment does not skip the normal checks.
+
+## What to run before different kinds of changes
+
+### Backend-only change
+
+Usually enough:
+
+```bash
+cd game-server
+go test ./...
+```
+
+### Frontend-only change
+
+Usually enough:
+
+```bash
+cd ui
+npm run build
+```
+
+### Reconnect, gameplay, or cross-stack change
+
+Run both:
+
+```bash
+cd game-server && go test ./...
+cd ui && npm run build
+cd ui && npm run test:e2e
+```
+
+## Screenshots and visual artifacts
+
+The repo also keeps screenshot artifacts under `docs/screenshots/`. Those are more documentation/review assets than formal tests, but they are useful when you want to show UI evolution over time.


### PR DESCRIPTION
## Summary
- rewrite the README as a top-level guide to the project and its major components
- add architecture, gameplay, development, and testing docs under `docs/`
- rewrite deployment docs around local Compose, staging on the homelab stack, and Fly production
- expand the AI-assisted development write-up to cover later docs and ops work

## Testing
- markdown link check for README + docs/*.md
