### PR TITLE
Complete stale game cleanup

### DIFF
--- a/game-server/cmd/flipcup/main.go
+++ b/game-server/cmd/flipcup/main.go
@@ -2,47 +2,93 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"time"
 
 	"flip-cup/internal/game"
-	"flip-cup/internal/transport/ws"
 	"flip-cup/internal/transport/api"
+	"flip-cup/internal/transport/ws"
 	"github.com/gorilla/mux"
 )
 
+type runtimeConfig struct {
+	port            string
+	cleanupInterval time.Duration
+	staleAfter      time.Duration
+}
+
 func main() {
-    log.Println("✅ Flip Cup server started")
-	
+	log.Println("✅ Flip Cup server started")
+
+	config, err := loadRuntimeConfig()
+	if err != nil {
+		log.Fatalf("invalid runtime configuration: %v", err)
+	}
+
 	manager := game.NewGameManager()
 
-	// Start background cleanup task
 	go func() {
-		// Run cleanup every 30 minutes, removing games inactive for > 1 hour
-		ticker := time.NewTicker(30 * time.Minute)
+		ticker := time.NewTicker(config.cleanupInterval)
 		defer ticker.Stop()
+
 		for range ticker.C {
-			manager.CleanupStaleGames(1 * time.Hour)
+			manager.CleanupStaleGames(config.staleAfter)
 		}
 	}()
 
-	// Create a new router
 	r := mux.NewRouter()
-
-	//  WebSocket route *  handler
 	r.HandleFunc("/ws", ws.HandleWebSocketConnection(manager))
+	api.SetupRoutes(manager, config.staleAfter, r)
 
-	//  HTTP routes
-	api.SetupRoutes(manager, r)
+	log.Printf(
+		"Server running at http://localhost:%s (cleanup_interval=%s stale_after=%s)",
+		config.port,
+		config.cleanupInterval,
+		config.staleAfter,
+	)
+	log.Fatal(http.ListenAndServe(":"+config.port, api.WithCORS(r)))
+}
 
-	// Start the server
+func loadRuntimeConfig() (runtimeConfig, error) {
+	cleanupInterval, err := readDurationEnv("GAME_CLEANUP_INTERVAL", game.DefaultCleanupInterval)
+	if err != nil {
+		return runtimeConfig{}, err
+	}
+
+	staleAfter, err := readDurationEnv("GAME_STALE_AFTER", game.DefaultStaleAfter)
+	if err != nil {
+		return runtimeConfig{}, err
+	}
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
-	log.Printf("Server running at http://localhost:%s", port)
-	log.Fatal(http.ListenAndServe(":"+port, api.WithCORS(r)))
+
+	return runtimeConfig{
+		port:            port,
+		cleanupInterval: cleanupInterval,
+		staleAfter:      staleAfter,
+	}, nil
 }
 
+func readDurationEnv(name string, fallback time.Duration) (time.Duration, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback, nil
+	}
+
+	value, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a valid duration: %w", name, err)
+	}
+
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", name)
+	}
+
+	return value, nil
+}

--- a/game-server/cmd/flipcup/main_test.go
+++ b/game-server/cmd/flipcup/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"flip-cup/internal/game"
+)
+
+func TestLoadRuntimeConfigDefaults(t *testing.T) {
+	t.Setenv("PORT", "")
+	t.Setenv("GAME_CLEANUP_INTERVAL", "")
+	t.Setenv("GAME_STALE_AFTER", "")
+
+	config, err := loadRuntimeConfig()
+	if err != nil {
+		t.Fatalf("expected defaults to load, got error: %v", err)
+	}
+
+	if config.port != "8080" {
+		t.Fatalf("expected default port 8080, got %s", config.port)
+	}
+
+	if config.cleanupInterval != game.DefaultCleanupInterval {
+		t.Fatalf("expected cleanup interval %s, got %s", game.DefaultCleanupInterval, config.cleanupInterval)
+	}
+
+	if config.staleAfter != game.DefaultStaleAfter {
+		t.Fatalf("expected stale threshold %s, got %s", game.DefaultStaleAfter, config.staleAfter)
+	}
+}
+
+func TestLoadRuntimeConfigFromEnv(t *testing.T) {
+	t.Setenv("PORT", "19090")
+	t.Setenv("GAME_CLEANUP_INTERVAL", "15m")
+	t.Setenv("GAME_STALE_AFTER", "45m")
+
+	config, err := loadRuntimeConfig()
+	if err != nil {
+		t.Fatalf("expected config from env to load, got error: %v", err)
+	}
+
+	if config.port != "19090" {
+		t.Fatalf("expected port 19090, got %s", config.port)
+	}
+
+	if config.cleanupInterval != 15*time.Minute {
+		t.Fatalf("expected cleanup interval 15m, got %s", config.cleanupInterval)
+	}
+
+	if config.staleAfter != 45*time.Minute {
+		t.Fatalf("expected stale threshold 45m, got %s", config.staleAfter)
+	}
+}
+
+func TestLoadRuntimeConfigRejectsInvalidDuration(t *testing.T) {
+	t.Setenv("GAME_CLEANUP_INTERVAL", "not-a-duration")
+
+	_, err := loadRuntimeConfig()
+	if err == nil {
+		t.Fatal("expected invalid duration error")
+	}
+}
+
+func TestLoadRuntimeConfigRejectsNonPositiveDuration(t *testing.T) {
+	t.Setenv("GAME_STALE_AFTER", "0s")
+
+	_, err := loadRuntimeConfig()
+	if err == nil {
+		t.Fatal("expected non-positive duration error")
+	}
+}

--- a/game-server/internal/game/cleanup.go
+++ b/game-server/internal/game/cleanup.go
@@ -1,0 +1,8 @@
+package game
+
+import "time"
+
+const (
+	DefaultCleanupInterval = 30 * time.Minute
+	DefaultStaleAfter      = time.Hour
+)

--- a/game-server/internal/game/cleanup_test.go
+++ b/game-server/internal/game/cleanup_test.go
@@ -3,41 +3,55 @@ package game
 import (
 	"testing"
 	"time"
+
 	"flip-cup/internal/quiz"
 )
 
 func TestCleanupStaleGames(t *testing.T) {
-	// 1. Setup
 	gm := NewGameManager()
-	
-	// Create a minimal QuestionFile structure
 	qf := &quiz.QuestionFile{
-		Filename: "test.yaml",
-		// We don't need actual questions for this test
+		Filename:  "test.yaml",
 		Questions: []*quiz.Question{},
 	}
 
-	// 2. Create games
-	g1 := gm.NewGame(qf)
-	g2 := gm.NewGame(qf)
+	fresh := gm.NewGame(qf)
+	stale := gm.NewGame(qf)
 
-	// 3. Manipulate LastActivity
-	// g1 is active now (default NewGame sets to Now())
-	// g2 should be stale. We set it to 2 hours ago.
-	g2.mu.Lock()
-	g2.LastActivity = time.Now().Add(-2 * time.Hour)
-	g2.mu.Unlock()
+	stale.mu.Lock()
+	stale.LastActivity = time.Now().Add(-2 * time.Hour)
+	stale.mu.Unlock()
 
-	// 4. Run Cleanup with 1 hour threshold
-	// g2 is 2 hours old, so it > 1 hour, should be deleted.
-	gm.CleanupStaleGames(1 * time.Hour)
+	gm.CleanupStaleGames(time.Hour)
 
-	// 5. Verify
-	if gm.GetGame(g1.ID) == nil {
-		t.Errorf("Game 1 (active) should still exist")
+	if gm.GetGame(fresh.ID) == nil {
+		t.Fatalf("fresh game %s should still exist", fresh.ID)
 	}
-	if gm.GetGame(g2.ID) != nil {
-		t.Errorf("Game 2 (stale) should have been deleted")
+
+	if gm.GetGame(stale.ID) != nil {
+		t.Fatalf("stale game %s should have been deleted", stale.ID)
+	}
+}
+
+func TestPruneStaleGamesReturnsDeletedIDs(t *testing.T) {
+	gm := NewGameManager()
+	qf := &quiz.QuestionFile{Filename: "test.yaml"}
+
+	fresh := gm.NewGame(qf)
+	stale := gm.NewGame(qf)
+	stale.LastActivity = time.Now().Add(-(30*time.Minute + 5*time.Minute))
+
+	deleted := gm.PruneStaleGames(30 * time.Minute)
+
+	if len(deleted) != 1 {
+		t.Fatalf("expected 1 deleted game, got %d", len(deleted))
+	}
+
+	if deleted[0] != stale.ID {
+		t.Fatalf("expected stale game ID %s, got %s", stale.ID, deleted[0])
+	}
+
+	if gm.GetGame(fresh.ID) == nil {
+		t.Fatalf("fresh game %s should still exist", fresh.ID)
 	}
 }
 
@@ -45,27 +59,26 @@ func TestGetStaleGames(t *testing.T) {
 	gm := NewGameManager()
 	qf := &quiz.QuestionFile{Filename: "test.yaml"}
 
-	g1 := gm.NewGame(qf)
-	g2 := gm.NewGame(qf)
+	fresh := gm.NewGame(qf)
+	stale := gm.NewGame(qf)
 
-	// Make g2 stale
-	g2.mu.Lock()
-	g2.LastActivity = time.Now().Add(-40 * time.Minute)
-	g2.mu.Unlock()
+	stale.mu.Lock()
+	stale.LastActivity = time.Now().Add(-40 * time.Minute)
+	stale.mu.Unlock()
 
-	// Threshold 30m
-	stale := gm.GetStaleGames(30 * time.Minute)
+	staleGames := gm.GetStaleGames(30 * time.Minute)
 
-	if len(stale) != 1 {
-		t.Errorf("Expected 1 stale game, got %d", len(stale))
-	} else if stale[0].ID != g2.ID {
-		t.Errorf("Expected stale game ID %s, got %s", g2.ID, stale[0].ID)
+	if len(staleGames) != 1 {
+		t.Fatalf("expected 1 stale game, got %d", len(staleGames))
 	}
 
-    // Ensure g1 (active) is not returned
-    for _, s := range stale {
-        if s.ID == g1.ID {
-            t.Errorf("Active game %s should not be marked stale", g1.ID)
-        }
-    }
+	if staleGames[0].ID != stale.ID {
+		t.Fatalf("expected stale game ID %s, got %s", stale.ID, staleGames[0].ID)
+	}
+
+	for _, candidate := range staleGames {
+		if candidate.ID == fresh.ID {
+			t.Fatalf("fresh game %s should not be marked stale", fresh.ID)
+		}
+	}
 }

--- a/game-server/internal/game/manager.go
+++ b/game-server/internal/game/manager.go
@@ -1,90 +1,104 @@
 package game
 
 import (
-    "sync"
-    "time"
-    "flip-cup/internal/quiz" 
-	"flip-cup/internal/utils"
 	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"flip-cup/internal/quiz"
+	"flip-cup/internal/utils"
 )
 
 type GameManager struct {
-    games map[string]*Game
-    mu    sync.Mutex
+	games map[string]*Game
+	mu    sync.Mutex
 }
 
 func NewGameManager() *GameManager {
-    return &GameManager{
-        games: make(map[string]*Game),
-    }
+	return &GameManager{
+		games: make(map[string]*Game),
+	}
 }
 
 func (gm *GameManager) NewGame(questionFile *quiz.QuestionFile) *Game {
-    g := NewGame(questionFile)
-    g.ID = utils.RandID()
+	g := NewGame(questionFile)
+	g.ID = utils.RandID()
 
-    gm.mu.Lock()
-    defer gm.mu.Unlock()
-    gm.games[g.ID] = g
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+	gm.games[g.ID] = g
 
-    return g
+	return g
 }
 
 func (gm *GameManager) GetGame(id string) *Game {
-    gm.mu.Lock()
-    defer gm.mu.Unlock()
-    return gm.games[id]
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+	return gm.games[id]
 }
 
 func (gm *GameManager) GetAllGames() []*Game {
-    gm.mu.Lock()
-    defer gm.mu.Unlock()
-    all := []*Game{}
-    for _, g := range gm.games {
-        all = append(all, g)
-    }
-    return all
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	all := make([]*Game, 0, len(gm.games))
+	for _, g := range gm.games {
+		all = append(all, g)
+	}
+
+	return all
 }
 
 func (gm *GameManager) DeleteGameByID(id string) error {
-    gm.mu.Lock()
-    defer gm.mu.Unlock()
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
 
-    if _, exists := gm.games[id]; !exists {
-        return fmt.Errorf("game with ID %s not found", id)
-    }
+	if _, exists := gm.games[id]; !exists {
+		return fmt.Errorf("game with ID %s not found", id)
+	}
 
-    delete(gm.games, id)
-    return nil
+	delete(gm.games, id)
+	return nil
 }
 
 func (gm *GameManager) GetStaleGames(maxAge time.Duration) []*Game {
-    gm.mu.Lock()
-    defer gm.mu.Unlock()
-    stale := []*Game{}
-    for _, g := range gm.games {
-        if g.IsStale(maxAge) {
-            stale = append(stale, g)
-        }
-    }
-    return stale
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	stale := []*Game{}
+	for _, g := range gm.games {
+		if g.IsStale(maxAge) {
+			stale = append(stale, g)
+		}
+	}
+
+	return stale
+}
+
+func (gm *GameManager) PruneStaleGames(maxAge time.Duration) []string {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	deleted := []string{}
+	for id, g := range gm.games {
+		if g.IsStale(maxAge) {
+			delete(gm.games, id)
+			deleted = append(deleted, id)
+		}
+	}
+
+	return deleted
 }
 
 func (gm *GameManager) CleanupStaleGames(maxAge time.Duration) {
-    gm.mu.Lock()
-    defer gm.mu.Unlock()
+	deleted := gm.PruneStaleGames(maxAge)
+	if len(deleted) == 0 {
+		return
+	}
 
-    count := 0
-    for id, g := range gm.games {
-        // We use a small method on Game to safely check time
-        if g.IsStale(maxAge) {
-             fmt.Printf("🧹 Cleaning up stale game: %s\n", id)
-            delete(gm.games, id)
-            count++
-        }
-    }
-    if count > 0 {
-        fmt.Printf("🧹 Cleaned up %d stale games\n", count)
-    }
+	for _, id := range deleted {
+		log.Printf("🧹 cleaned up stale game: %s", id)
+	}
+	log.Printf("🧹 cleaned up %d stale games", len(deleted))
 }
-

--- a/game-server/internal/transport/api/games.go
+++ b/game-server/internal/transport/api/games.go
@@ -3,122 +3,80 @@ package api
 
 import (
 	"encoding/json"
-	"net/http"
 	"log"
+	"net/http"
 	"time"
+
 	"flip-cup/internal/game"
 	"github.com/gorilla/mux"
 )
 
-//
-// GET: /api/games/{active|inactive|stale}
-//
-func fetchGames(manager *game.GameManager) http.HandlerFunc {
+type deleteGamesResponse struct {
+	Status       string   `json:"status"`
+	DeletedCount int      `json:"deletedCount"`
+	DeletedIDs   []string `json:"deletedIds"`
+}
+
+// GET: /games/{active|inactive|stale}
+func fetchGames(manager *game.GameManager, staleAfter time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)              // get path variables
-		status := vars["status"]         // "active" or "inactive" or "stale"
-        var activeFilter *bool = nil
+		status := mux.Vars(r)["status"]
+		log.Printf("fetchGames called with status=%s", status)
 
+		var response []game.GameSnapshot
 
-		// Fetch all games from the manager
-        log.Println("🎯 fetchGames called") 
-		var games []*game.Game
-
-		if status == "stale" {
-			games = manager.GetStaleGames(30 * time.Minute)
-		} else {
-			games = manager.GetAllGames()
-		}
-
-		var response = []game.GameSnapshot{}
-        if status == "active" {
-            activeFilter = boolPtr(true)
-        } else if status == "inactive" {
-            activeFilter = boolPtr(false)
-        } else if status == "stale" {
-			// No extra filter needed, GetStaleGames already filtered
-        } else {
-			// if you want, return 404 or 400 on invalid status
-			http.Error(w, "Invalid status", http.StatusBadRequest)
+		switch status {
+		case "active":
+			for _, g := range manager.GetAllGames() {
+				if g.Active {
+					response = append(response, g.Snapshot())
+				}
+			}
+		case "inactive":
+			for _, g := range manager.GetAllGames() {
+				if !g.Active {
+					response = append(response, g.Snapshot())
+				}
+			}
+		case "stale":
+			for _, g := range manager.GetStaleGames(staleAfter) {
+				response = append(response, g.Snapshot())
+			}
+		default:
+			http.Error(w, "invalid status", http.StatusBadRequest)
 			return
 		}
 
-		for _, g := range games {
-			if status == "stale" {
-				response = append(response, g.Snapshot())
-			} else if activeFilter == nil || g.Active == *activeFilter {
-				response = append(response, g.Snapshot())
-			}
-		}
-
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(response)
 	}
 }
 
-//
-// DELETE: /api/games/{active|inactive}
-//
-func deleteGames(manager *game.GameManager) http.HandlerFunc {
+// DELETE: /games/stale
+func deleteStaleGames(manager *game.GameManager, staleAfter time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)              // get path variables
-		status := vars["status"]         // "active" or "inactive"
-        var activeFilter *bool = nil
-
-
-		// Fetch all games from the manager
-        log.Println("🎯 fetchGames called") 
-		games := manager.GetAllGames()
-
-
-		var response = []game.GameSnapshot{}
-        if status == "active" {
-            activeFilter = boolPtr(true)
-        } else if status == "inactive" {
-            activeFilter = boolPtr(false)
-        } else {
-			// if you want, return 404 or 400 on invalid status
-			http.Error(w, "Invalid status", http.StatusBadRequest)
-			return
-		}
-
-		for _, g := range games {
-			if activeFilter == nil || g.Active == *activeFilter {
-                err := manager.DeleteGameByID(g.ID)
-                if err != nil {
-                    http.Error(w, "Game not found or could not be deleted", http.StatusNotFound)
-                    return
-                }
-			}
-		}
+		deletedIDs := manager.PruneStaleGames(staleAfter)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		_ = json.NewEncoder(w).Encode(deleteGamesResponse{
+			Status:       "stale",
+			DeletedCount: len(deletedIDs),
+			DeletedIDs:   deletedIDs,
+		})
 	}
 }
 
-
-
-//
-// DELETE: /api/games/{id}
-//
+// DELETE: /games/{id}
 func deleteGame(manager *game.GameManager) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        vars := mux.Vars(r)
-        id := vars["id"]
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		log.Printf("deleting game with ID: %s", id)
 
-        log.Printf("Deleting game with ID: %s\n", id)
+		if err := manager.DeleteGameByID(id); err != nil {
+			http.Error(w, "game not found or could not be deleted", http.StatusNotFound)
+			return
+		}
 
-        err := manager.DeleteGameByID(id)
-        if err != nil {
-            http.Error(w, "Game not found or could not be deleted", http.StatusNotFound)
-            return
-        }
-
-        w.WriteHeader(http.StatusNoContent) // 204 No Content on success
-    }
-}
-
-func boolPtr(b bool) *bool {
-    return &b
+		w.WriteHeader(http.StatusNoContent)
+	}
 }

--- a/game-server/internal/transport/api/games_test.go
+++ b/game-server/internal/transport/api/games_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"flip-cup/internal/game"
+	"flip-cup/internal/quiz"
+)
+
+func TestDeleteStaleGamesPrunesStaleGames(t *testing.T) {
+	manager := game.NewGameManager()
+	qf := &quiz.QuestionFile{Filename: "test.yaml"}
+
+	fresh := manager.NewGame(qf)
+	stale := manager.NewGame(qf)
+	stale.LastActivity = time.Now().Add(-(30*time.Minute + 5*time.Minute))
+
+	req := httptest.NewRequest(http.MethodDelete, "/games/stale", nil)
+	rec := httptest.NewRecorder()
+
+	deleteStaleGames(manager, 30*time.Minute).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var response deleteGamesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if response.Status != "stale" {
+		t.Fatalf("expected status stale, got %s", response.Status)
+	}
+
+	if response.DeletedCount != 1 {
+		t.Fatalf("expected 1 deleted game, got %d", response.DeletedCount)
+	}
+
+	if len(response.DeletedIDs) != 1 || response.DeletedIDs[0] != stale.ID {
+		t.Fatalf("expected deleted stale ID %s, got %v", stale.ID, response.DeletedIDs)
+	}
+
+	if manager.GetGame(stale.ID) != nil {
+		t.Fatalf("stale game %s should have been deleted", stale.ID)
+	}
+
+	if manager.GetGame(fresh.ID) == nil {
+		t.Fatalf("fresh game %s should still exist", fresh.ID)
+	}
+}

--- a/game-server/internal/transport/api/router.go
+++ b/game-server/internal/transport/api/router.go
@@ -2,22 +2,17 @@
 package api
 
 import (
-	"github.com/gorilla/mux"
+	"time"
+
 	"flip-cup/internal/game"
+	"github.com/gorilla/mux"
 )
 
-// SetupRoutes sets up HTTP endpoints 
-func SetupRoutes(manager *game.GameManager, r *mux.Router) {
-	r.HandleFunc("/games/{status}", fetchGames(manager)).Methods("GET")
-	r.HandleFunc("/games/{status}", deleteGames(manager)).Methods("DELETE")
+// SetupRoutes sets up HTTP endpoints.
+func SetupRoutes(manager *game.GameManager, staleAfter time.Duration, r *mux.Router) {
+	r.HandleFunc("/games/{status:active|inactive|stale}", fetchGames(manager, staleAfter)).Methods("GET")
+	r.HandleFunc("/games/stale", deleteStaleGames(manager, staleAfter)).Methods("DELETE")
 	r.HandleFunc("/games/{id}", deleteGame(manager)).Methods("DELETE")
 	r.HandleFunc("/quizzes", fetchQuestionFiles())
-    r.PathPrefix("/").Handler(SPAHandler("public"))
-
-/**
-	$active ... get from url 
-	r.HandleFunc("/games/active", fetchGames(manager, $active))
-*/
-
+	r.PathPrefix("/").Handler(SPAHandler("public"))
 }
-


### PR DESCRIPTION
## Summary
- make stale-game cleanup configurable with runtime env vars
- add explicit stale-game pruning support to the game manager and API
- add backend tests for runtime config loading and stale deletion behavior

## Testing
- cd game-server && go test ./...
